### PR TITLE
Add 'limit_fields' attribute to serializer 'Meta'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,6 +78,8 @@ class ArticleDynSerializer(DynModelSerializer):
 *fields_param* in Meta corresponds to list of fields, passed as coma separated GET parameter
 
 ### Set view or viewset to use dynamic serializer
+There are two options to make serializer dynamic. Instantiate serializer with keyword 
+argument `limit_fields = True`. Keyword argument overrides `limit_fields` value from `Meta`
 ```python
 class ArticleViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Article.objects.all().order_by('id')
@@ -87,6 +89,21 @@ class ArticleViewSet(viewsets.ReadOnlyModelViewSet):
         context['request'] = self.request
         s = ArticleDynSerializer(*args, context=context, limit_fields=True, **kwargs)
         return s
+```
+Or made serializer dynamic by default. Add `limit_fields = True` attribute to serializer `Meta`
+```python
+class ArticleDynSerializer(DynModelSerializer):
+    author = AuthorDynSerializer(required=False)
+
+    class Meta:
+        model = Article
+        fields_param = 'article_fields'
+        fields = ['id', 'title', 'created', 'updated', 'content', 'author']
+        limit_fields = True
+
+class ArticleViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Article.objects.all().order_by('id') 
+    serializer_class = ArticleDynSerializer
 ```
 **Important!** Dyn serializer requires explicit *limit_fields* set to True to work as dynamic, otherwise it's working as ordinary model serializer. Also *request* parameter is required in context, otherwise it will not be able to get which parameters to load.
 

--- a/rest_framework_dyn_serializer.py
+++ b/rest_framework_dyn_serializer.py
@@ -9,18 +9,15 @@ class DynModelSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         self._requested_fields = []
 
-        limit_fields = kwargs.pop('limit_fields', False)
         s_type = type(self)
         assert hasattr(self.Meta, 'model'), '{} Meta.model param is required'.format(s_type)
-
-        if hasattr(self.Meta, 'default_fields'):
-            self.default_fields = list(self.Meta.default_fields)
-        else:
-            self.default_fields = ['id']
-
-        self.set_allowed_fields()
         assert hasattr(self.Meta, 'fields_param'), \
             '{} Meta.fields_param param cannot be empty'.format(s_type)
+
+        self.default_fields = list(getattr(self.Meta, 'default_fields', ['id']))
+        self.limit_fields = kwargs.pop('limit_fields', getattr(self.Meta, 'limit_fields', False))
+
+        self.set_allowed_fields()
 
         for field_name in self.default_fields:
             assert field_name in self._allowed_fields, '{} Meta.default_fields contains field "{}"'\
@@ -28,8 +25,6 @@ class DynModelSerializer(serializers.ModelSerializer):
                                                                                         field_name)
 
         super(DynModelSerializer, self).__init__(*args, **kwargs)
-
-        self.limit_fields = limit_fields
 
         if self.limit_fields:
             request = self.get_request()

--- a/test_samples/sample/sampleapp/tests.py
+++ b/test_samples/sample/sampleapp/tests.py
@@ -79,7 +79,8 @@ class MainTest(TestCase):
         assert 'birth_date' not in author, author
 
     def test_list_articles_with_author_extended_fields(self):
-        response = self.client.get('/article/?article_fields=id,author&author_fields=id,name,birth_date')
+        query = '/article/?article_fields=id,author&author_fields=id,name,birth_date'
+        response = self.client.get(query)
 
         assert response.status_code == 200, response.status_code
 
@@ -104,6 +105,28 @@ class MainTest(TestCase):
         assert 'author' in response_json, response_json
 
         author = response_json['author']
-        assert author == {'id': self.author1.id,
-                          'name': 'author 1',
-                          'birth_date': '1985-01-31'}, author
+        expected_author = {
+            'id': self.author1.id,
+            'name': 'author 1',
+            'birth_date': '1985-01-31'
+        }
+        assert author == expected_author, author
+
+    def test_limit_fields_as_serializer_meta_attribute(self):
+        url = '/article_limit_fields/{}/'.format(self.articles[0].id)
+        query = 'article_fields=id,author&author_fields=id,name'
+
+        response = self.client.get('{}?{}'.format(url, query))
+
+        assert response.status_code == 200, response.status_code
+
+        response_json = response.json()
+        assert 'author' in response_json, response_json
+        assert 'content' not in response_json, response_json
+
+        author = response_json['author']
+        expected_author = {
+            'id': self.author1.id,
+            'name': 'author 1',
+        }
+        assert author == expected_author, author

--- a/test_samples/sample/sampleapp/urls.py
+++ b/test_samples/sample/sampleapp/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import url, include
 
 from rest_framework.routers import DefaultRouter
-from test_samples.sample.sampleapp.views import ArticleViewSet
+from test_samples.sample.sampleapp import views
 
 router = DefaultRouter()
-router.register('article', ArticleViewSet)
+router.register('article', views.ArticleViewSet)
+router.register('article_limit_fields', views.ArticleViewSetLimitFields)
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/test_samples/sample/sampleapp/views.py
+++ b/test_samples/sample/sampleapp/views.py
@@ -1,5 +1,4 @@
-from django.shortcuts import render
-from rest_framework import views, generics, status, serializers, viewsets
+from rest_framework import viewsets
 
 # Create your views here.
 from rest_framework_dyn_serializer import DynModelSerializer
@@ -37,3 +36,18 @@ class ArticleViewSet(viewsets.ReadOnlyModelViewSet):
         context['request'] = self.request
         s = ArticleDynSerializer(*args, context=context, limit_fields=True, **kwargs)
         return s
+
+
+class LimitFieldsArticle(DynModelSerializer):
+    author = AuthorDynSerializer(required=False, limit_fields=True)
+
+    class Meta:
+        model = Article
+        fields_param = 'article_fields'
+        fields = ['id', 'title', 'created', 'updated', 'content', 'author']
+        limit_fields = True
+
+
+class ArticleViewSetLimitFields(viewsets.ReadOnlyModelViewSet):
+    serializer_class = LimitFieldsArticle
+    queryset = Article.objects.all().order_by('id')


### PR DESCRIPTION
Add ability to make serializer dynamic without passing `limit_fields = True` to constructor by settings additional attibute `limit_fields = True` to serializer `Meta`