### PR TITLE
Fields override

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,13 +68,17 @@ class AuthorDynSerializer(DynModelSerializer):
 
 
 class ArticleDynSerializer(DynModelSerializer):
-    author = AuthorDynSerializer(required=False)
+    author = AuthorDynSerializer(
+        fields=['id', 'name', 'birth_date'],
+        required=False
+    )
 
     class Meta:
         model = Article
         fields_param = 'article_fields'
         fields = ['id', 'title', 'created', 'updated', 'content', 'author']
 ```
+*fields* in init is an optional parameter to override the list of fields declared in Meta class
 *fields_param* in Meta corresponds to list of fields, passed as coma separated GET parameter
 
 ### Set view or viewset to use dynamic serializer

--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,7 @@ class ArticleDynSerializer(DynModelSerializer):
         fields = ['id', 'title', 'created', 'updated', 'content', 'author']
 ```
 *fields* in init is an optional parameter to override the list of fields declared in Meta class
+
 *fields_param* in Meta corresponds to list of fields, passed as coma separated GET parameter
 
 ### Set view or viewset to use dynamic serializer

--- a/test_samples/sample/sampleapp/urls.py
+++ b/test_samples/sample/sampleapp/urls.py
@@ -1,12 +1,13 @@
 from django.conf.urls import url, include
 
 from rest_framework.routers import DefaultRouter
-from test_samples.sample.sampleapp import views, views_author
+from test_samples.sample.sampleapp import views, views_author, views_review
 
 router = DefaultRouter()
 router.register('article', views.ArticleViewSet)
 router.register('article_limit_fields', views.ArticleViewSetLimitFields)
 router.register('author', views_author.AuthorViewSet)
+router.register('review', views_review.ReviewViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/test_samples/sample/sampleapp/views_review.py
+++ b/test_samples/sample/sampleapp/views_review.py
@@ -1,0 +1,28 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework import viewsets
+from rest_framework_dyn_serializer import DynModelSerializer
+from test_samples.sample.sampleapp.models import Review
+
+
+class UserDynSerializer(DynModelSerializer):
+    class Meta:
+        model = get_user_model()
+        fields_param = 'user_fields'
+        fields = ['id', 'username', 'email', 'first_name', 'last_name']
+        limit_fields = True
+
+
+class ReviewDynSerializer(DynModelSerializer):
+    user = UserDynSerializer(fields=['id', 'first_name', 'last_name'])
+
+    class Meta:
+        model = Review
+        fields_param = 'review_fields'
+        fields = ['id', 'summary', 'content', 'stars', 'article', 'user']
+        limit_fields = True
+
+
+class ReviewViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = ReviewDynSerializer
+    queryset = Review.objects.all()


### PR DESCRIPTION
Adds optional fields param to override the list of fields in meta class during declaration so that a serializer can be re-used without exposing via query params private information in other places. [Targets issue-8](https://github.com/Nepherhotep/django-rest-framework-dyn-serializer/issues/8)